### PR TITLE
multi-thread capability of interpreter. 

### DIFF
--- a/odcl/multiInterpreter_pipeline.py
+++ b/odcl/multiInterpreter_pipeline.py
@@ -1,0 +1,64 @@
+#mike's modules for drawing, inference, tiling, and camera respectively
+from pipeline import TargetDrawer
+from interpreter import TargetInterpreter, BBox, Target
+from tile_image import Tiler
+from vsutils import VideoStreamCV
+
+
+#multithreading module for inference
+from threadingInterpreter import threadingInterpreter
+
+#from threading library
+from threading import Lock
+
+#argparse to get command inputs
+import argparse
+
+from termcolor import colored
+
+import cv2
+'''
+this module is a test for the multi-threading module.
+it is currently not designed to support inputs.
+
+
+'''
+
+if __name__ == '__main__':
+    #initialising all necessary objects
+    cam = VideoStreamCV(src=1)
+    interTPU = TargetInterpreter('model_edgetpu.tflite', 'labels.txt', "tpu", 0.33, order_key='efficientdetd2') 
+    interCPU = TargetInterpreter('model.tflite', 'labels.txt', "cpu", 0.33, order_key='efficientdetd2')
+    draw = TargetDrawer(interTPU.labels)
+    tiler = Tiler(448,100)
+
+
+    #initialising multi-thread safety locks
+    gen_lock = Lock()
+    target_lock = Lock()
+
+
+    #initialising threads
+    worker0 = threadingInterpreter(interTPU, tiler, gen_lock, target_lock,0)
+    worker1 = threadingInterpreter(interCPU, tiler, gen_lock, target_lock,1)
+
+    worker0.start()
+    worker1.start()
+    
+    while True:
+        img = cam.get_img()
+        targets = []
+
+        gen = tiler.get_tiles(img.shape)
+
+        worker0.start_work(img, gen, targets)
+        worker1.start_work(img, gen, targets)
+        while worker0.working or worker1.working:
+            pass
+        #finished inference
+
+        merged_targets = tiler.merge_overlapping(targets)
+        img = draw.draw_all(img, merged_targets)
+        cv2.imshow("image", img)
+        if cv2.waitKey(25) & 0xFF == ord('q'):
+            break

--- a/odcl/seq_pipeline.py
+++ b/odcl/seq_pipeline.py
@@ -1,0 +1,47 @@
+from interpreter import TargetInterpreter, BBox, Target
+from vsutils import VideoStreamCV
+import argparse
+import numpy as np
+import cv2
+import colorsys, random, math, platform
+from pipeline import TargetDrawer
+
+def imageSegment(img, segments):
+    M,N = img.shape[0]//segments, img.shape[1]//segments
+    return np.array([[img[x*M:x*M+M,y*N:y*N+N] for y in range(0,segments)] for x in range(0,segments)])
+
+def offset_targets(targets, offset, img_shape, segment):
+    x_offset, y_offset = offset
+    for i in range(len(targets)):
+        targets[i] = Target(targets[i].id,targets[i].score,BBox(
+        targets[i].bbox.xmin / segment + float(x_offset) / img_shape[1],
+        targets[i].bbox.ymin / segment + float(y_offset) / img_shape[0],
+        targets[i].bbox.xmax / segment + float(x_offset) / img_shape[1],
+        targets[i].bbox.ymax / segment + float(y_offset) / img_shape[0]
+        ))
+
+if __name__ == '__main__':
+
+    tpu_model = 'mobilenet_edge.tflite'
+    tpu_labels = 'coco_labels.txt'
+
+    target_interTPU = TargetInterpreter(tpu_model, tpu_labels, "tpu", 0.33, "mn")
+    vs = VideoStreamCV(src=0)
+    drawTPU = TargetDrawer(target_interTPU.labels)
+
+    segment = 3
+    while True:
+        img = vs.get_img()
+        M,N = img.shape[0]//segment, img.shape[1]//segment
+        array_imgs = imageSegment(img,segment)
+        targets = []
+        for i in range(0,segment**2,1):
+            target_interTPU.interpret(array_imgs[i//segment,i%segment])
+            offset_targets(target_interTPU.targets, ((i%segment)*N, (i//segment)*M), img.shape, segment)
+            targets = targets + target_interTPU.targets
+        
+        img = drawTPU.draw_all(img,targets)
+        cv2.imshow("image",img)
+        if cv2.waitKey(25) & 0xFF == ord("q"):
+            break
+

--- a/odcl/threadingInterpreter.py
+++ b/odcl/threadingInterpreter.py
@@ -1,0 +1,128 @@
+import threading
+from threading import Thread
+
+'''
+    Required Modules:
+        interpreter.py
+        tile_image.py
+'''
+
+
+'''
+    Worker class for creating worker threads solely on processing tiled images.
+    Written 11/3/2021. 
+'''
+class threadingInterpreter(Thread):
+    def __init__(self, targetInterpreter, tiler, genLock, targetLock, worker_id):
+        '''
+            Attributes:
+            -----------
+            worker_id -> int
+                        thread # of this particular worker object
+
+            targetInterpreter -> targetInterpreter Object (in interpreter.py)
+                                    contains a specific model instance to perform inference
+
+            tiler -> Tiler Object (tile_image.py)
+                    
+
+            genLock, targetLock -> threading.lock object (threading module)
+                        an object that can be used to Lock actions to prevent multiple threads
+                        from accessing same variables. (common multithreading problem)
+
+
+            img -> numpy array or opencv array [shape = (m,n,3)] mxn dimension
+                    current image for thread to work on
+            
+            
+            Inheritance:
+            ------------
+                Inherits from Thread which gives this multi-threading abilities.
+
+
+            Notes:
+            -------
+             IMPORTANT: MAKE SURE THAT ALL WORKER THREAD INSTANCES SHARE THE SAME -> img, tileGen, and genLock.
+             this is because the sole design of this multithreaded class is based around those assumptions and designed as such.
+
+        '''
+        self.id = worker_id
+        #a targetInterpreter for the thread to use
+        self.targetInterpreter = targetInterpreter
+        self.tiler = tiler
+        
+        super().__init__(daemon=True) 
+        #setting daemon = True means these threads are killed upon death of main.
+
+        self.working = False #indicates whether thread is currently working
+        self.img = None #represents current image being worked on by thread (pass by reference)
+        self.tileGen = None
+        self.targetList = None
+
+
+        self.genLock = genLock
+        self.targetLock = targetLock
+
+    def start_work(self, img, tileGen, targetList): #this sets up the base image to tile on
+        '''
+        Parameters:
+        ----------
+        img: numpy array of np.uint8
+                shape (m,n,3) where mxn is dimension of image.
+        tileGen: generator of tile 
+
+        Returns:
+        --------
+        None
+
+        Description/Notes:
+            the img is a pass-by-reference. therefore,
+            no expensive calls are being made by calling this function.
+
+            this image will be set as current image that worker thread will work on.
+        '''
+        self.img = img
+        self.tileGen = tileGen
+        self.targetList = targetList
+        self.working = True
+
+
+    def run(self):
+        '''
+        No Parameters
+        No Returns
+
+        Job:
+        ------
+        This thread's sole purpose is to wait for an image and generator from Tiler Object to be fed
+        into this object.
+
+        Afterwards, it will access the generator and perform inference on whatever tile it gets.
+        for multiple threads, there is a Lock placed to prevent multiple access to generator at once.
+
+        '''
+        while True:
+            while not self.working:
+                pass #if nothing is in queue, don't do anything
+            
+            #after above while, we can say that there is an image to work on, and we tiles to pull from
+            try:
+                self.genLock.acquire() #prevent multiple access of generator
+                (ymin, ymax) , (xmin, xmax), (i,j) = next(self.tileGen)
+                self.genLock.release()
+
+                self.targetInterpreter.interpret(self.img[ymin:ymax, xmin:xmax]) #this will update the targetInterpreter
+
+                self.targetLock.acquire()
+                for target in self.targetInterpreter.targets:
+                    self.targetList.append(self.tiler.parse_localTarget(target, xmin, ymin))
+                self.targetLock.release()
+            except StopIteration: 
+                #the only "error" this code will handle is StopIteration from the generator in Tile
+                #this error signals that generator is empty.
+                self.working = False
+                if self.genLock.locked(): self.genLock.release()
+                if self.targetLock.locked(): self.targetLock.release()
+
+
+

--- a/odcl/tile_image.py
+++ b/odcl/tile_image.py
@@ -208,6 +208,25 @@ class Tiler(object):
         new_ymax = max(bbA.ymax, bbB.ymax)
         return BBox(new_xmin, new_ymin, new_xmax, new_ymax)
 
+    def parse_localTarget(self, target: 'Target object from Interpreter', wl: int, hl: int):
+        '''
+        Inputs:
+        --------
+            target -> Target (from interpreter.py)
+            wl -> location of min x value of box
+            hl -> location of min y value of box
+
+        Outputs:
+        --------
+            target -> Target (from interpreter.py)
+
+        Description:
+        ------------
+            reformats tiled target information (local position) to the overall image's location (global).
+        '''
+        bbox = self.tile2board(target.bbox, wl, hl)
+        return Target(target.id, target.score, bbox)
+
 
 if __name__ == "__main__":
     ap = ArgumentParser()


### PR DESCRIPTION
I only added one method into the TileImage in order to get multi-thread to work. It essentially does what your tile_image does in the main, but it's a method.

This is to ensure that multi-thread class in is the least intrusive and is as modular as possible.
A quick implementation of it working is in the multiInterpreter_pipeline.py . 