### PR TITLE
Data recording on ODCL node 

### DIFF
--- a/odcl_node.py
+++ b/odcl_node.py
@@ -77,8 +77,8 @@ def get_next_in_dir(datadir: Path, suffix: str, k=5):
 
     Returns
     -------
-    str
-        string with enumeration length k plus suffix
+    tuple(int, str)
+        integer, and len(k) string representation
     """
     # find length k collection of digits
     digit_re = k * [r"\d"]
@@ -97,28 +97,30 @@ def get_next_in_dir(datadir: Path, suffix: str, k=5):
                 max_num = current
 
     # return padded string
-    return str(max_num + 1).rjust(k, "0") + suffix
+    return max_num, str(max_num + 1).rjust(k, "0")
 
 
 if __name__ == "__main__":
     rospy.init_node("odcl_node", anonymous=True)
+    rospy.loginfo("Started ODCL node...")
+
     # odcl data dir is set to a rospy param
     data_dir = rospy.get_param("/odcl/odcldir", "~/odcldata")
     # make a folder with today's date
     data_dir = Path(data_dir).resolve() / datetime.date.today().strftime("%Y%m%d")
-    os.makedirs(data_dir, exist_ok=True)
     # make a directory to save raw images
-    raw_image_dir = data_dir / "rawimg"
+    raw_image_dir = data_dir / "raw"
     # make a directory to save cropped images
-    crp_image_dir = data_dir / "crpimg"
-    for dir in (raw_image_dir, crp_image_dir):
+    crp_image_dir = data_dir / "crop"
+    for dir in (data_dir, raw_image_dir, crp_image_dir):
         os.makedirs(dir, exist_ok=True)
 
     # save odcl data txtfile
-    odcl_data_num = get_next_in_dir(data_dir, "-data.csv")
-    odcl_data_file = data_dir / odcl_data_num + "-data.csv"
-    # write headers to file
-    headers = "frame_no,in-frame-no,img_path,score,class,shapecolor,lettercolor,latitude,longitude\n"
+    run_id, run_id_str = get_next_in_dir(data_dir, "-data.csv")
+    odcl_data_file = data_dir / str(run_id_str + "-data.csv")
+
+    # write CSV headers to file
+    headers = "run_id,frame_no,target_no,target_id,img_path,crop_path,score,class,shape_color,letter_color,latitude,longitude,inference_time\n"
     with open(odcl_data_file, "a") as f:
         f.write(headers)
 
@@ -131,34 +133,38 @@ if __name__ == "__main__":
     capture.set(cv2.CAP_PROP_FRAME_HEIGHT, 3000)
     odcl_node = OdclNode(model_path, labels_path)
 
-    frameno = 0
+    frameno = 1
     while True:
         if capture.isOpened():
-            rospy.loginfo(f"New frame {frameno}")
-
             # read raw image from camera
             status, image_raw = capture.read()
 
+            # get frame number
+            frameno_str = str(frameno).rjust(5)
+            frame_id = run_id_str + "_" + frameno_str
+            rospy.loginfo(f"Captured Frame {frameno} with id {frame_id}")
+
             # save raw image and log
-            raw_img_path = str(
-                raw_image_dir / get_next_in_dir(raw_image_dir, suffix="-raw.jpg")
-            )
-            cv2.imwrite(raw_img_path)
-            rospy.loginfo(f"Raw image saved to {raw_img_path}")
+            raw_img_path = raw_image_dir / str(frame_id + ".jpg")
+            cv2.imwrite(raw_img_path, image_raw)
+            rospy.loginfo(f"\tRaw image saved: {raw_img_path}")
 
             # run the pipeline
+            t0 = time.time()
             targets = odcl_node.pipeline.run(
                 image_raw,
                 odcl_node.gps,
                 odcl_node.altitude,
                 quat=odcl_node.quat,
             )
+            # inference time in ms
+            inftime = (time.time() - t0) * 1000
 
-            rospy.loginfo("Performed inference on raw image.")
-            rospy.loginfo(f"Found {len(targets)} targets.")
-            frameno += 1
+            rospy.loginfo(f"\tPerformed inference on raw image, took {inftime}ms")
+            rospy.loginfo(f"\tFound {len(targets)} targets.")
 
             for i, target in enumerate(targets):
+                targetno = str(i).rjust(2)
                 # unpack target information
                 lat = target["lat"]
                 lon = target["lon"]
@@ -170,17 +176,23 @@ if __name__ == "__main__":
                 score = round(target["score"], 3)
 
                 # log to rospy
-                targetinfo = f"Target {i}/{len(targets)}: shape={shape} ({score*100}%), scolor={scolor}, lcolor={lcolor}, lat={lat}, lon={lon}"
+                targetinfo = f"\tTarget {targetno}/{len(targets)}: shape={shape} ({score*100}%), scolor={scolor}, lcolor={lcolor}, lat={lat}, lon={lon}"
                 rospy.loginfo(targetinfo)
 
+                # save cropped image with unique identifier
+                targetid = frame_id + "_" + targetno
+                crop_fname = crp_image_dir / str(targetid + "jpg")
+                cv2.imwrite(crop_fname, img)
+                rospy.loginfo("\tSaved cropped image to {crop_fname}")
+
                 # write to csv
-                targetcsvline = f"{frameno},{i},{raw_img_path},{score},{shape},{scolor},{lcolor},{lat},{lon}\n"
+                targetcsvline = f"{run_id},{frameno},{targetno},{targetid},"
+                targetcsvline += f"{raw_img_path},{crop_fname},"
+                targetcsvline += f"{score},{shape},{scolor},{lcolor},{lat},{lon},"
+                targetcsvline += f"{inftime}\n"
                 with open(odcl_data_file, "a") as f:
                     f.write(targetcsvline)
 
-                # save cropped image with unique identifier
-                frameno_str = str(frameno).rjust(5)
-                i_str = str(i).rjust(2)
-                identifier = odcl_data_num[:5] + frameno_str + i_str
-                crop_fname = crp_image_dir / str(identifier + "jpg")
-                cv2.imwrite(crop_fname, img)
+            rospy.loginfo("\tRecorded data to {odcl_data_file}")
+
+            frameno += 1

--- a/odcl_node.py
+++ b/odcl_node.py
@@ -107,7 +107,8 @@ if __name__ == "__main__":
     # odcl data dir is set to a rospy param
     data_dir = rospy.get_param("/odcl/odcldir", "~/odcldata")
     # make a folder with today's date
-    data_dir = Path(data_dir).resolve() / datetime.date.today().strftime("%Y%m%d")
+    todaysdate = datetime.date.today().strftime("%Y%m%d")
+    data_dir = Path(data_dir).resolve() / todaysdate
     # make a directory to save raw images
     raw_image_dir = data_dir / "raw"
     # make a directory to save cropped images
@@ -120,7 +121,7 @@ if __name__ == "__main__":
     odcl_data_file = data_dir / str(run_id_str + "-data.csv")
 
     # write CSV headers to file
-    headers = "run_id,frame_no,target_no,target_id,img_path,crop_path,score,class,shape_color,letter_color,latitude,longitude,inference_time\n"
+    headers = "run_id,frame_no,target_no,target_id,img_path,crop_path,score,class,shape_color,letter_color,latitude,longitude,inference_time,captime\n"
     with open(odcl_data_file, "a") as f:
         f.write(headers)
 
@@ -138,6 +139,7 @@ if __name__ == "__main__":
         if capture.isOpened():
             # read raw image from camera
             status, image_raw = capture.read()
+            captime = datetime.datetime.now().strftime("%Y%m%d %H%M%S%f%p")
 
             # get frame number
             frameno_str = str(frameno).rjust(5)
@@ -164,7 +166,7 @@ if __name__ == "__main__":
             rospy.loginfo(f"\tFound {len(targets)} targets.")
 
             for i, target in enumerate(targets):
-                targetno = str(i).rjust(2)
+                targetno = str(i).ljust(2)
                 # unpack target information
                 lat = target["lat"]
                 lon = target["lon"]
@@ -189,7 +191,7 @@ if __name__ == "__main__":
                 targetcsvline = f"{run_id},{frameno},{targetno},{targetid},"
                 targetcsvline += f"{raw_img_path},{crop_fname},"
                 targetcsvline += f"{score},{shape},{scolor},{lcolor},{lat},{lon},"
-                targetcsvline += f"{inftime}\n"
+                targetcsvline += f"{inftime},{captime}\n"
                 with open(odcl_data_file, "a") as f:
                     f.write(targetcsvline)
 

--- a/odcl_node.py
+++ b/odcl_node.py
@@ -2,18 +2,19 @@
 
 import rospy
 import cv2
-import time
-import os
+import time, datetime
+import os, re
 import numpy as np
+from pathlib import Path
 
-#uavfpy module code
+# uavfpy module code
 from uavfpy1.odcl.inference import TargetInterpreter, Tiler
 from uavfpy1.odcl.color import Color
 from uavfpy1.odcl.pipeline import Pipeline
 from uavfpy1.odcl.location import Geolocation
 from uavfpy1.odcl.utils.drawer import TargetDrawer
 
-#mavros package imports
+# mavros package imports
 from mavros_msgs.msg import State
 from sensor_msgs.msg import Imu, NavSatFix
 
@@ -23,86 +24,163 @@ BASE_DIR = "."
 class OdclNode:
     def __init__(self, model_path, labels_path):
         interpreter = TargetInterpreter(
-            model_path, 
-            labels_path, 
-            "tpu", 
-            thresh=0.4, 
-            order_key = "efficientdetd2"
+            model_path, labels_path, "tpu", thresh=0.4, order_key="efficientdetd2"
         )
         tiler = Tiler(384, 50)
         drawer = TargetDrawer(interpreter.labels)
         color = Color()
         geolocator = Geolocation()
-        
 
         self.pipeline = Pipeline(interpreter, tiler, color, geolocator, drawer)
 
-        self.GPS_sub = rospy.Subscriber('/mavros/global_position/global', NavSatFix, self.GPS_callback)
-        self.IMU_sub = rospy.Subscriber('/mavros/imu/data', Imu, self.IMU_callback)
+        self.GPS_sub = rospy.Subscriber(
+            "/mavros/global_position/global", NavSatFix, self.GPS_callback
+        )
+        self.IMU_sub = rospy.Subscriber("/mavros/imu/data", Imu, self.IMU_callback)
 
         self.longitude = 0
         self.latitude = 0
-        self.altitude = 1 
+        self.altitude = 1
 
-        self.quat = (0,0,0,1)
-        self.gps = (0,0)
+        self.quat = (0, 0, 0, 1)
+        self.gps = (0, 0)
         self.altitude = 0
 
     def GPS_callback(self, msg):
         self.gps = (msg.latitude, msg.longitude)
         self.altitude = msg.altitude
 
-
     def IMU_callback(self, msg):
         x = msg.orientation.x
         y = msg.orientation.y
         z = msg.orientation.z
         w = msg.orientation.w
-        self.quat = (x,y,z,w)
+        self.quat = (x, y, z, w)
 
 
-if __name__=='__main__':
-    rospy.init_node('odcl_node', anonymous=True)
+def get_next_in_dir(datadir: Path, suffix: str, k=5):
+    """Get next image in directory `datadir` with optional suffix `suffix`
 
+    Parameters
+    ----------
+    datadir : Path
+        _description_
+    suffix : str, by default ""
+        optional suffix for files
+    k : int, optional
+        enumeration prefix length, by default 5
+        for example, with k=5, images are labeled
+        00000
+        00001
+        00002
+        ...
+
+    Returns
+    -------
+    str
+        string with enumeration length k plus suffix
+    """
+    # find length k collection of digits
+    digit_re = k * [r"\d"]
+    # find suffix and only suffix
+    suffix_re = rf"({suffix})"
+    # a regex with the two together
+    fname_re = re.compile(rf"/{digit_re}{suffix_re}/")
+
+    # get max num using re
     max_num = 0
-    for filename in os.listdir(BASE_DIR):
-        if filename.endswith("odcl_data.txt"):
-            curr_num = int(filename[0: filename.index("odcl_data.txt")])
-            if curr_num > max_num:
-                max_num = curr_num
-    f_name = str(max_num + 1) + "odcl_data.txt" 
-            
+    for name in os.listdir(datadir):
+        search = re.search(fname_re, name)
+        if search is not None:
+            current = int(search.group(0)[:k])
+            if max_num < current:
+                max_num = current
+
+    # return padded string
+    return str(max_num + 1).rjust(k, "0") + suffix
+
+
+if __name__ == "__main__":
+    rospy.init_node("odcl_node", anonymous=True)
+    # odcl data dir is set to a rospy param
+    data_dir = rospy.get_param("/odcl/odcldir", "~/odcldata")
+    # make a folder with today's date
+    data_dir = Path(data_dir).resolve() / datetime.date.today().strftime("%Y%m%d")
+    os.makedirs(data_dir, exist_ok=True)
+    # make a directory to save raw images
+    raw_image_dir = data_dir / "rawimg"
+    # make a directory to save cropped images
+    crp_image_dir = data_dir / "crpimg"
+    for dir in (raw_image_dir, crp_image_dir):
+        os.makedirs(dir, exist_ok=True)
+
+    # save odcl data txtfile
+    odcl_data_num = get_next_in_dir(data_dir, "-data.csv")
+    odcl_data_file = data_dir / odcl_data_num + "-data.csv"
+    # write headers to file
+    headers = "frame_no,in-frame-no,img_path,score,class,shapecolor,lettercolor,latitude,longitude\n"
+    with open(odcl_data_file, "a") as f:
+        f.write(headers)
 
     model_path = "efdet.tflite"
     labels_path = "labels.txt"
-    
+
     vid_capture_src = 0
     capture = cv2.VideoCapture(vid_capture_src)
     capture.set(cv2.CAP_PROP_FRAME_WIDTH, 4000)
     capture.set(cv2.CAP_PROP_FRAME_HEIGHT, 3000)
-
     odcl_node = OdclNode(model_path, labels_path)
 
-    print('before whiel')
-    while(True):
+    frameno = 0
+    while True:
         if capture.isOpened():
-            status, image_raw = capture.read()
-            target_data_list = odcl_node.pipeline.run(image_raw, odcl_node.gps, odcl_node.altitude, quat=odcl_node.quat)
-            index = 1
-            for data in target_data_list:
-                line_string = "{}: Target longitude: {}, Target latitude{}, Shape color: {}, Letter color: {}, Shape: {}\n".format(
-                    index, 
-                    data[0],
-                    data[1], 
-                    data[2], 
-                    data[3], 
-                    data[4]
-                )
-                print('writing')
-                f = open(f_name, "a")
-                f.write(line_string)
-                f.close()
-                print('done writing')
-                index += 1
-            print('done forloop')
+            rospy.loginfo(f"New frame {frameno}")
 
+            # read raw image from camera
+            status, image_raw = capture.read()
+
+            # save raw image and log
+            raw_img_path = str(
+                raw_image_dir / get_next_in_dir(raw_image_dir, suffix="-raw.jpg")
+            )
+            cv2.imwrite(raw_img_path)
+            rospy.loginfo(f"Raw image saved to {raw_img_path}")
+
+            # run the pipeline
+            targets = odcl_node.pipeline.run(
+                image_raw,
+                odcl_node.gps,
+                odcl_node.altitude,
+                quat=odcl_node.quat,
+            )
+
+            rospy.loginfo("Performed inference on raw image.")
+            rospy.loginfo(f"Found {len(targets)} targets.")
+            frameno += 1
+
+            for i, target in enumerate(targets):
+                # unpack target information
+                lat = target["lat"]
+                lon = target["lon"]
+                scolor = target["scolor_str"]
+                lcolor = target["lcolor_str"]
+                shape = target["class"]
+                img = target["croppedimg"]
+                # score -> percentage
+                score = round(target["score"], 3)
+
+                # log to rospy
+                targetinfo = f"Target {i}/{len(targets)}: shape={shape} ({score*100}%), scolor={scolor}, lcolor={lcolor}, lat={lat}, lon={lon}"
+                rospy.loginfo(targetinfo)
+
+                # write to csv
+                targetcsvline = f"{frameno},{i},{raw_img_path},{score},{shape},{scolor},{lcolor},{lat},{lon}\n"
+                with open(odcl_data_file, "a") as f:
+                    f.write(targetcsvline)
+
+                # save cropped image with unique identifier
+                frameno_str = str(frameno).rjust(5)
+                i_str = str(i).rjust(2)
+                identifier = odcl_data_num[:5] + frameno_str + i_str
+                crop_fname = crp_image_dir / str(identifier + "jpg")
+                cv2.imwrite(crop_fname, img)


### PR DESCRIPTION
400bd60 has a few things that should be useful for testing 

- it creates test folders automatically.
- the typical directory where test data is saved is configurable via a ROS parameter called, `/odcl/odcldir`
- by default (i.e. if unset) the test data is saved to `~/odcldata/`
- when the node is run, it will create a folder in `~/odcldata/` with today's date. So each day of testing will have its own date, making test data easier to manage
- two folders are made, `raw`, and `crop`, where images are stored
- a CSV file of each "run" of the odcl pipeline is also created. following An's idea each run has a prefix (01, 02...)

The raw image is saved with a unique identifier in `/raw/`
The cropped image of each target is saved with a unique identifier in `/crop/`

9e9360f has a few additions

Each found target is given a unique identifier, which is the date, run, frame, target.

- along with the 5 odcl parameters (lat lon scolor lcolor shape) we also have several new parameters and metadata
     - run number, frame number, target number, and target ID
     - time taken to inference
     - class confidence score

5ed9350 

Whenever an image is captured as part of the pipeline, the exact capture time is recorded and saved

